### PR TITLE
use predownloaded databases - with read permissions

### DIFF
--- a/lib/radis-lambda/Dockerfile
+++ b/lib/radis-lambda/Dockerfile
@@ -6,5 +6,9 @@ RUN python3.8 -m pip install -r requirements.txt -t .
 
 RUN python3.8 download_hitran.py
 
+RUN chmod 666 $(find ~/.radisdb -type f)
+RUN chmod 777 $(find ~/.radisdb -type d)
+RUN chmod 666 ~/radis.json
+
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/lib/radis-lambda/app.py
+++ b/lib/radis-lambda/app.py
@@ -1,7 +1,14 @@
 import json
 import traceback
+import os
+import shutil
+
+if not os.path.exists("/tmp/radis.json"):
+    shutil.copy("/root/radis.json", "/tmp/radis.json")
 
 import radis
+from radis.misc.config import get_config
+print(get_config())
 
 
 def lambda_handler(event, context):
@@ -29,7 +36,8 @@ def lambda_handler(event, context):
                 for species in payload["species"]
             },
             # TODO: Hard-coding "1,2,3" as the isotopologue for the time-being
-            isotope={species["molecule"]: "1,2,3" for species in payload["species"]},
+            isotope={species["molecule"]
+                : "1,2,3" for species in payload["species"]},
             pressure=payload["pressure"],
             Tgas=payload["tgas"],
             Tvib=payload["tvib"],
@@ -70,18 +78,18 @@ def lambda_handler(event, context):
         wunit = spectrum.get_waveunit()
         iunit = "default"
         x, y = spectrum.get(payload["mode"], wunit=wunit, Iunit=iunit)
-        
+
         # Reduce payload size
         if len(spectrum) * 8 * 2 > 3e6:
             print("Reducing the payload size")
             # payload limit is 6 MB, we set a limit at ~4 MB here
-            # one float is about 8 bytes 
+            # one float is about 8 bytes
             # we return 2 arrays (w, I)
             #     (note: we could avoid returning the full w-range, and recompute it on the client
             #     from the x min, max and step --> less data transfer. TODO )
-            resample = int(len(spectrum) * 8 * 2  // 3e6)
+            resample = int(len(spectrum) * 8 * 2 // 3e6)
             x, y = x[::resample], y[::resample]
-            
+
         result = json.dumps(
             {
                 "data": {


### PR DESCRIPTION
New attempt following #497, this time setting read/write permissions to database files to avoid the PermissionERrors identified in #498 

From https://docs.aws.amazon.com/lambda/latest/dg/troubleshooting-deployment.html

> The Lambda runtime needs permission to read the files in your deployment package 