### PR TITLE
Revert "use predownloaded databases - with read permissions"

### DIFF
--- a/lib/radis-lambda/Dockerfile
+++ b/lib/radis-lambda/Dockerfile
@@ -6,9 +6,5 @@ RUN python3.8 -m pip install -r requirements.txt -t .
 
 RUN python3.8 download_hitran.py
 
-RUN chmod 666 $(find ~/.radisdb -type f)
-RUN chmod 777 $(find ~/.radisdb -type d)
-RUN chmod 666 ~/radis.json
-
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/lib/radis-lambda/app.py
+++ b/lib/radis-lambda/app.py
@@ -1,14 +1,7 @@
 import json
 import traceback
-import os
-import shutil
-
-if not os.path.exists("/tmp/radis.json"):
-    shutil.copy("/root/radis.json", "/tmp/radis.json")
 
 import radis
-from radis.misc.config import get_config
-print(get_config())
 
 
 def lambda_handler(event, context):
@@ -36,8 +29,7 @@ def lambda_handler(event, context):
                 for species in payload["species"]
             },
             # TODO: Hard-coding "1,2,3" as the isotopologue for the time-being
-            isotope={species["molecule"]
-                : "1,2,3" for species in payload["species"]},
+            isotope={species["molecule"]: "1,2,3" for species in payload["species"]},
             pressure=payload["pressure"],
             Tgas=payload["tgas"],
             Tvib=payload["tvib"],
@@ -78,18 +70,18 @@ def lambda_handler(event, context):
         wunit = spectrum.get_waveunit()
         iunit = "default"
         x, y = spectrum.get(payload["mode"], wunit=wunit, Iunit=iunit)
-
+        
         # Reduce payload size
         if len(spectrum) * 8 * 2 > 3e6:
             print("Reducing the payload size")
             # payload limit is 6 MB, we set a limit at ~4 MB here
-            # one float is about 8 bytes
+            # one float is about 8 bytes 
             # we return 2 arrays (w, I)
             #     (note: we could avoid returning the full w-range, and recompute it on the client
             #     from the x min, max and step --> less data transfer. TODO )
-            resample = int(len(spectrum) * 8 * 2 // 3e6)
+            resample = int(len(spectrum) * 8 * 2  // 3e6)
             x, y = x[::resample], y[::resample]
-
+            
         result = json.dumps(
             {
                 "data": {


### PR DESCRIPTION
Reverts suzil/radis-app#506

```
[ERROR] PermissionError: [Errno 13] Permission denied: '/root/radis.json'
Traceback (most recent call last):
  File "/var/lang/lib/python3.8/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/var/lang/lib/python3.8/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/task/app.py", line 7, in <module>
    shutil.copy("/root/radis.json", "/tmp/radis.json")
  File "/var/lang/lib/python3.8/shutil.py", line 418, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/var/lang/lib/python3.8/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
```

I think these docs here: https://docs.aws.amazon.com/lambda/latest/dg/troubleshooting-deployment.html do not apply due to launching from a Docker container.