### PR TITLE
Fix simulating slit in the backend

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -34,7 +34,6 @@ class Payload(BaseModel):
     simulate_slit: Optional[int] = None
     mode: Literal["absorbance", "transmittance_noslit", "radiance_noslit", "transmittance", "radiance"]
     database: Literal["hitran", "geisa"]
-    use_simulate_slit: bool = False
 
 
 @app.post("/calculate-spectrum")
@@ -61,7 +60,8 @@ async def calculate_spectrum(payload: Payload):
             databank=payload.database,
             use_cached=True,
         )
-        if payload.use_simulate_slit is True:
+        if payload.simulate_slit:
+            print("Simulating slit")
             spectrum.apply_slit(payload.simulate_slit, "nm")
 
     except radis.misc.warning.EmptyDatabaseError:


### PR DESCRIPTION
`use_simulate_slit` was not being passed to the backend. Either way, we don't need it, so let's just check if the payload has a non-zero value for `simulate_slit`.

We have a new issue when applying the slit simulation due to another issue. Here's part of the trace:
```py
  File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant
```

It looks like some value returned after applying the slit is ~~some out-of-range float~~ a NaN, so we need to figure out what we want to do for those values.