### PR TITLE
Fix 639

### DIFF
--- a/frontend/src/components/CalcSpectrum.tsx
+++ b/frontend/src/components/CalcSpectrum.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
@@ -45,6 +45,14 @@ export const CalcSpectrum: React.FC = () => {
 
   const [progress, setProgress] = useState(0); //control the progress bar
   const [useHitemp, setUseHitemp] = useState<boolean>(false); //hitemp
+
+  useEffect(() => {
+    if (useGesia) {
+      // GESIA does not work for non-equilibrium calculations
+      setIsNonEquilibrium(false);
+    }
+  }, [useGesia]);
+
   const Schema = yup.object().shape({
     useNonEqi: yup.boolean(),
     use_simulate_slit: yup.boolean(),

--- a/frontend/src/components/fields/MoleculeSelector/MoleculeSelector.tsx
+++ b/frontend/src/components/fields/MoleculeSelector/MoleculeSelector.tsx
@@ -37,23 +37,22 @@ export const MoleculeSelector: React.FC<MoleculeSelectorProps> = ({
 }) => {
   const [input, setInput] = useState("");
 
+  let moleculeOptions = moleculeOptionsEquimolecules;
+  if (isNonEquilibrium) {
+    moleculeOptions = moleculeOptionsNonequimolecules;
+  } else if (isGeisa) {
+    moleculeOptions = moleculeOptionsGesia;
+  } else if (isHitemp) {
+    moleculeOptions = moleculeOptionsHitemp;
+  }
+
   return (
     <Autocomplete
       id="molecule-selector"
       className="MoleculeSelector"
-      options={
-        isHitemp
-          ? moleculeOptionsHitemp.map((value) => addSubscriptsToMolecule(value))
-          : isGeisa
-          ? moleculeOptionsGesia.map((value) => addSubscriptsToMolecule(value))
-          : isNonEquilibrium
-          ? moleculeOptionsNonequimolecules.map((value) =>
-              addSubscriptsToMolecule(value)
-            )
-          : moleculeOptionsEquimolecules.map((value) =>
-              addSubscriptsToMolecule(value)
-            )
-      }
+      options={moleculeOptions.map((molecule) =>
+        addSubscriptsToMolecule(molecule)
+      )}
       renderInput={(params) => (
         <TextField
           {...params}


### PR DESCRIPTION
- Fixes non-equilibrium molecule options for HITEMP (Fixes https://github.com/suzil/radis-app/issues/639)
- Fixes TRot and TVib appearing for GESIA even though it doesn't support non-equilibrium calculations

## Demo of fixes
https://user-images.githubusercontent.com/13723264/186548593-b204626f-acb0-4aa2-bc7b-bde7890ec0a4.mov
